### PR TITLE
Support gemfile key on source and matrix

### DIFF
--- a/lib/vx/builder/script/ruby.rb
+++ b/lib/vx/builder/script/ruby.rb
@@ -13,7 +13,7 @@ module Vx
             env.before_install.tap do |i|
               i << 'eval "$(rbenv init -)" || true'
               i << "rbenv shell #{make_rbenv_version_command env}"
-              i << 'export BUNDLE_GEMFILE=${PWD}/Gemfile'
+              i << "export BUNDLE_GEMFILE=${PWD}/#{gemfile(env)}"
               i << 'export GEM_HOME=$HOME/cached/rubygems'
             end
 
@@ -36,6 +36,15 @@ module Vx
 
           def rvm(env)
             env.source.rvm.first
+          end
+
+          def gemfile(env)
+            if env.source.gemfile
+              env.source.gemfile.first
+            else
+              env.source.gemfile = ["Gemfile"]
+              gemfile(env)
+            end
           end
 
           def make_rbenv_version_command(env)

--- a/lib/vx/builder/source/constants.rb
+++ b/lib/vx/builder/source/constants.rb
@@ -3,7 +3,7 @@ module Vx
     class Source
 
       LANGS    = %w{ rvm scala java go }.freeze
-      KEYS     = %w{ services before_script script before_install }.freeze
+      KEYS     = %w{ gemfile services before_script script before_install }.freeze
       AS_ARRAY = (KEYS + LANGS).freeze
 
     end

--- a/lib/vx/builder/source/matrix.rb
+++ b/lib/vx/builder/source/matrix.rb
@@ -3,7 +3,7 @@ module Vx
     class Source
       class Matrix
 
-        KEYS = (Source::LANGS + %w{ matrix_env:env }).freeze
+        KEYS = (Source::LANGS + %w{ gemfile matrix_env:env }).freeze
         NOT_MATRIX_KEYS = %w{ script before_script services before_install }
 
         attr_reader :source

--- a/spec/fixtures/travis.yml
+++ b/spec/fixtures/travis.yml
@@ -1,5 +1,7 @@
 rvm:
   - 2.0.0
+gemfile:
+  - 'Gemfile'
 before_script:
   - "echo before_script"
 before_install:

--- a/spec/lib/builder/script/ruby_spec.rb
+++ b/spec/lib/builder/script/ruby_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Vx::Builder::Script::Ruby do
+  let(:app)    { ->(_) { 0 } }
+  let(:script) { described_class.new app }
+  let(:env)    { create :env }
+  let(:run)    { script.call env }
+  subject { run }
+
+  it { should eq 0 }
+
+  context "run it" do
+    let(:command) { create :command_from_env, env: env }
+    before { run }
+
+    it "should be success" do
+      puts env
+      puts command
+
+      system( command )
+      expect($?.to_i).to eq 0
+    end
+  end
+
+end

--- a/spec/lib/builder/source_spec.rb
+++ b/spec/lib/builder/source_spec.rb
@@ -7,6 +7,7 @@ describe Vx::Builder::Source do
 
   its(:attributes)    { should be }
   its(:rvm)           { should eq %w{ 2.0.0 } }
+  its(:gemfile)       { should eq %w{ Gemfile } }
   its(:before_script) { should eq ["echo before_script"] }
   its(:script)        { should eq ["RAILS_ENV=test ls -1 && echo DONE!"] }
 
@@ -28,6 +29,7 @@ describe Vx::Builder::Source do
     context "build new instance" do
       let(:expected) { {
         "rvm"            => ["2.0.0"],
+        "gemfile"        => ["Gemfile"],
         "before_script"  => ["echo before_script"],
         "before_install" => ["echo before_install"],
         "script"         => ["RAILS_ENV=test ls -1 && echo DONE!"],
@@ -50,6 +52,7 @@ describe Vx::Builder::Source do
       context "from_attributes" do
         let(:attrs) {{
           rvm:           "2.0.0",
+          gemfile:       "Gemfile",
           before_script: "echo before_script",
           before_install: "echo before_install",
           script:        "RAILS_ENV=test ls -1 && echo DONE!"
@@ -67,27 +70,27 @@ describe Vx::Builder::Source do
 
   context "to_matrix_s" do
     subject { config.to_matrix_s }
-    it { should eq 'rvm:2.0.0' }
+    it { should eq 'gemfile:Gemfile, rvm:2.0.0' }
 
     context "when many items" do
       before do
         mock(config).rvm { %w{ 1.9.3 2.0.0 } }
         mock(config).scala { %w{ 2.10.1 } }
       end
-      it { should eq "rvm:1.9.3, scala:2.10.1" }
+      it { should eq "gemfile:Gemfile, rvm:1.9.3, scala:2.10.1" }
     end
   end
 
   context "matrix_keys" do
     subject { config.matrix_keys }
-    it { should eq("rvm" => "2.0.0") }
+    it { should eq("rvm" => "2.0.0", "gemfile" => "Gemfile") }
 
     context "when many items" do
       before do
         mock(config).rvm { %w{ 1.9.3 2.0.0 } }
         mock(config).scala { %w{ 2.10.1 } }
       end
-      it { should eq({"rvm"=>"1.9.3", "scala"=>"2.10.1"}) }
+      it { should eq({"rvm"=>"1.9.3", "scala"=>"2.10.1", "gemfile" => "Gemfile"}) }
     end
   end
 

--- a/spec/support/create.rb
+++ b/spec/support/create.rb
@@ -20,9 +20,16 @@ def create(name, options = {})
 
   when :env
     OpenStruct.new(
-      init:   [],
-      source: create(:source),
-      task:   create(:task)
+      init:           [],
+      before_install: [],
+      install:        [],
+      announce:       [],
+      before_script:  [],
+      script:         [],
+      after_script:   [],
+      source:         create(:source),
+      task:           create(:task),
+      cache_key:      []
     )
 
   when :command_from_env


### PR DESCRIPTION
With this PR we build our matrix taking into account the gemfile key on the travis.yml files.

Besides I added a Gemfile as the default Gemfile, that was the previous behaviour.

I'm not sure I followed your code/spec conventions If not just let me know.

One thing I notice is that I wasn't able to test that the middleware are building the proper script using the gemfile keys, how can I add that?
